### PR TITLE
Sync Kaspa stack to upstream master b8deb638 (2.0.0).

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
  "hyper 1.9.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3354,8 +3354,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addresses"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "borsh",
  "js-sys",
@@ -3369,8 +3369,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-addressmanager"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "borsh",
  "igd-next",
@@ -3391,16 +3391,16 @@ dependencies = [
 
 [[package]]
 name = "kaspa-alloc"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "mimalloc",
 ]
 
 [[package]]
 name = "kaspa-build-info"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "duct",
  "faster-hex 0.9.0",
@@ -3408,8 +3408,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-connectionmanager"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "duration-string",
  "futures-util",
@@ -3426,8 +3426,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -3470,8 +3470,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-client"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "ahash",
  "borsh",
@@ -3500,8 +3500,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3539,8 +3539,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-notify"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
@@ -3559,8 +3559,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensus-wasm"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "cfg-if",
  "faster-hex 0.9.0",
@@ -3584,8 +3584,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-consensusmanager"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "duration-string",
  "futures",
@@ -3604,8 +3604,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3624,8 +3624,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-database"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "bincode",
  "enum-primitive-derive",
@@ -3647,8 +3647,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-client"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -3680,8 +3680,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -3712,8 +3712,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-grpc-server"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-stream",
@@ -3748,8 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-hashes"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "blake2b_simd",
  "blake3",
@@ -3769,8 +3769,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -3789,8 +3789,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-index-processor"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -3815,8 +3815,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-math"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "borsh",
  "faster-hex 0.9.0",
@@ -3835,16 +3835,16 @@ dependencies = [
 
 [[package]]
 name = "kaspa-merkle"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-hashes",
 ]
 
 [[package]]
 name = "kaspa-mining"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "futures-util",
  "itertools 0.13.0",
@@ -3869,8 +3869,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-mining-errors"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-consensus-core",
  "thiserror 2.0.18",
@@ -3878,8 +3878,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-muhash"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-hashes",
  "kaspa-math",
@@ -3889,8 +3889,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-notify"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -3921,8 +3921,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-flows"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -3958,8 +3958,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-lib"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "borsh",
  "ctrlc",
@@ -3990,8 +3990,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-p2p-mining"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-consensusmanager",
@@ -4008,8 +4008,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-perf-monitor"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-core",
  "log",
@@ -4021,8 +4021,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-pow"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "js-sys",
  "kaspa-consensus-client",
@@ -4037,8 +4037,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "async-trait",
@@ -4079,8 +4079,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-macros"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-error",
@@ -4092,8 +4092,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-rpc-service"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-trait",
  "kaspa-addresses",
@@ -4124,8 +4124,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-seq-commit"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-hashes",
  "kaspa-merkle",
@@ -4135,8 +4135,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "blake3",
  "kaspa-hashes",
@@ -4146,8 +4146,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-smt-store"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-consensus-core",
  "kaspa-core",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "kaspa-stratum-bridge"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4214,8 +4214,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-system-info"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "kaspa-utils",
  "mac_address",
@@ -4226,8 +4226,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -4269,8 +4269,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-txscript-errors"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "borsh",
  "kaspa-hashes",
@@ -4280,8 +4280,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -4306,8 +4306,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utils-tower"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -4323,8 +4323,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-utxoindex"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "futures",
  "kaspa-consensus-core",
@@ -4343,8 +4343,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wasm-core"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "faster-hex 0.9.0",
  "hexplay",
@@ -4355,8 +4355,8 @@ dependencies = [
 
 [[package]]
 name = "kaspa-wrpc-server"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-trait",
  "borsh",
@@ -4384,8 +4384,8 @@ dependencies = [
 
 [[package]]
 name = "kaspad"
-version = "1.3.0-toc.5"
-source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#d5205cc72ab7b811e88a23595dfac5b9facdeece"
+version = "2.0.0"
+source = "git+https://github.com/LiveLaughLove13/rusty-kaspa.git?branch=master#b8deb638dab0b60806e1c32b3b9d53f1b07a78a1"
 dependencies = [
  "async-channel 2.5.0",
  "cfg-if",
@@ -5534,7 +5534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6065,7 +6065,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ default-members = ["bridge"]
 
 [workspace.package]
 rust-version = "1.91.0"
-version = "1.3.0-toc.5"
+version = "2.0.0"
 authors = ["Kaspa developers"]
 license = "ISC"
 repository = "https://github.com/LiveLaughLove13/rusty-kaspa-stratum"


### PR DESCRIPTION
Bump workspace version and refresh git deps from d5205cc7 to b8deb638 (Toccata mainnet activation). No new upstream bridge/ commits in range; build, clippy, and lib tests pass unchanged.